### PR TITLE
Add chamber temperature client state

### DIFF
--- a/simplyprint_ws_client/core/client.py
+++ b/simplyprint_ws_client/core/client.py
@@ -142,7 +142,7 @@ _CLIENT_MSG_PRODUCERS = {
     FirmwareMsg: ["firmware"],
     FirmwareWarningMsg: ["firmware_warning"],
     ToolMsg: ["tools.*.active_material"],
-    TemperatureMsg: ["bed.temperature", "tools.*.temperature"],
+    TemperatureMsg: ["bed.temperature", "chamber.temperature", "tools.*.temperature"],
     AmbientTemperatureMsg: ["ambient_temperature.ambient"],
     StateChangeMsg: ["status"],
     JobInfoMsg: ["job_info"],

--- a/simplyprint_ws_client/core/state/__init__.py
+++ b/simplyprint_ws_client/core/state/__init__.py
@@ -474,6 +474,14 @@ class BedState(StateModel):
         return self.temperature.is_heating()
 
 
+class ChamberState(StateModel):
+    temperature: TemperatureState = Field(default_factory=TemperatureState)
+
+    def is_heating(self) -> bool:
+        """Returns True if the chamber is currently heating."""
+        return self.temperature.is_heating()
+
+
 class ToolState(StateModel):
     nozzle: int
     type: Optional[NozzleType] = None
@@ -728,6 +736,7 @@ class PrinterState(StateModel):
     # General state.
     status: Optional[PrinterStatus] = None
     bed: BedState = Field(default_factory=BedState)
+    chamber: ChamberState = Field(default_factory=ChamberState)
     tools: List[ToolState] = Field(default_factory=lambda: [ToolState(nozzle=0)])
     mms_layout: List[MaterialLayoutEntry] = Field(default_factory=list)
 
@@ -881,7 +890,7 @@ class PrinterState(StateModel):
         return PrinterStatus.is_printing(*status)
 
     def is_heating(self) -> bool:
-        return any([h.is_heating() for h in (self.bed.temperature, *self.tools)])
+        return any([h.is_heating() for h in (self.bed, self.chamber, *self.tools)])
 
     def populate_info_from_physical_machine(self, *skip: str):
         """Set information about the physical machine the client is running on."""

--- a/simplyprint_ws_client/core/ws_protocol/messages.py
+++ b/simplyprint_ws_client/core/ws_protocol/messages.py
@@ -704,6 +704,9 @@ class TemperatureMsg(ClientMsg[Literal[ClientMsgType.TEMPERATURES]]):
         if state.bed.temperature.model_has_changed:
             yield "bed", state.bed.temperature.to_list()
 
+        if state.chamber.temperature.model_has_changed:
+            yield "chamber", state.chamber.temperature.to_list()
+
         for i, tool in enumerate(state.tools):
             if not tool.temperature.model_has_changed:
                 continue
@@ -714,6 +717,9 @@ class TemperatureMsg(ClientMsg[Literal[ClientMsgType.TEMPERATURES]]):
         state.bed.model_reset_changed("temperature")
         state.bed.temperature.model_reset_changed()
 
+        state.chamber.model_reset_changed("temperature")
+        state.chamber.temperature.model_reset_changed()
+
         for tool in state.tools:
             tool.model_reset_changed("temperature")
             tool.temperature.model_reset_changed()
@@ -723,7 +729,8 @@ class TemperatureMsg(ClientMsg[Literal[ClientMsgType.TEMPERATURES]]):
         if any(
             "target" in x.model_self_changed_fields
             for x in chain(
-                (state.bed.temperature,), map(lambda t: t.temperature, state.tools)
+                (state.bed.temperature, state.chamber.temperature),
+                map(lambda t: t.temperature, state.tools),
             )
         ):
             return DispatchMode.DISPATCH

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -68,3 +68,29 @@ def test_multiple_tools_temperatures(client: Client):
     assert message.__class__ == TemperatureMsg
 
     assert message.data == {"tool0": [200, 250], "tool1": [180, 220]}
+
+
+def test_chamber_temperature(client: Client):
+    client.printer.chamber.temperature.actual = 45
+
+    messages, _ = client.consume()
+
+    assert len(messages) == 1
+
+    message = messages[0]
+
+    assert message.__class__ == TemperatureMsg
+    assert message.data == {"chamber": [45]}
+
+    message.reset_changes(client.printer)
+
+    client.printer.chamber.temperature.target = 60
+
+    messages, _ = client.consume()
+
+    assert len(messages) == 1
+
+    message = messages[0]
+
+    assert message.__class__ == TemperatureMsg
+    assert message.data == {"chamber": [45, 60]}


### PR DESCRIPTION
## Notice
- Based on https://github.com/SimplyPrint/simplyprint-ws-client/pull/13.
- Change this PR base to `main` after that peripherals PR has merged.

## Summary
- Add chamber temperature state to the SimplyPrint websocket client.
- Emit chamber temperature messages for current and target values.
- Cover chamber temperature output with a protocol test.

## Testing
- `uv run python -m pytest tests/test_temperature.py`